### PR TITLE
Fix: Change variable types from int to size_t

### DIFF
--- a/src/generation.hpp
+++ b/src/generation.hpp
@@ -195,7 +195,7 @@ private:
         size_t pop_count = m_vars.size() - m_scopes.back();
         m_output << "    add rsp, " << pop_count * 8 << "\n";
         m_stack_size -= pop_count;
-        for (int i = 0; i < pop_count; i++) {
+        for (size_t i = 0; i < pop_count; i++) {
             m_vars.pop_back();
         }
         m_scopes.pop_back();

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -295,7 +295,7 @@ public:
     }
 
 private:
-    [[nodiscard]] inline std::optional<Token> peek(int offset = 0) const
+    [[nodiscard]] inline std::optional<Token> peek(size_t offset = 0) const
     {
         if (m_index + offset >= m_tokens.size()) {
             return {};

--- a/src/tokenization.hpp
+++ b/src/tokenization.hpp
@@ -135,7 +135,7 @@ public:
     }
 
 private:
-    [[nodiscard]] inline std::optional<char> peek(int offset = 0) const
+    [[nodiscard]] inline std::optional<char> peek(size_t offset = 0) const
     {
         if (m_index + offset >= m_src.length()) {
             return {};


### PR DESCRIPTION
- Resolves implicit conversion error: 'int' to 'size_t'
- Eliminates warning: [-Werror,-Wsign-conversion]