### PR TITLE
fix issues in `ArenaAllocator`

### DIFF
--- a/src/arena.hpp
+++ b/src/arena.hpp
@@ -1,33 +1,69 @@
 #pragma once
 
-class ArenaAllocator {
+#include <cstddef>
+#include <cstdlib>
+#include <memory>
+#include <utility>
+
+class ArenaAllocator final {
 public:
-    inline explicit ArenaAllocator(size_t bytes)
-        : m_size(bytes)
+    explicit ArenaAllocator(const std::size_t max_num_bytes)
+        : m_size { max_num_bytes }
+        , m_buffer { new std::byte[max_num_bytes] }
+        , m_offset { m_buffer }
     {
-        m_buffer = static_cast<std::byte*>(malloc(m_size));
-        m_offset = m_buffer;
+    }
+
+    ArenaAllocator(const ArenaAllocator&) = delete;
+    ArenaAllocator& operator=(const ArenaAllocator&) = delete;
+
+    ArenaAllocator(ArenaAllocator&& other) noexcept
+        : m_size { std::exchange(other.m_size, 0) }
+        , m_buffer { std::exchange(other.m_buffer, nullptr) }
+        , m_offset { std::exchange(other.m_offset, nullptr) }
+    {
+    }
+
+    ArenaAllocator& operator=(ArenaAllocator&& other) noexcept
+    {
+        std::swap(m_size, other.m_size);
+        std::swap(m_buffer, other.m_buffer);
+        std::swap(m_offset, other.m_offset);
+        return *this;
     }
 
     template <typename T>
-    inline T* alloc()
+    [[nodiscard]] T* alloc()
     {
-        void* offset = m_offset;
-        m_offset += sizeof(T);
-        return static_cast<T*>(offset);
+        std::size_t remaining_num_bytes = m_size - static_cast<std::size_t>(m_offset - m_buffer);
+        auto pointer = static_cast<void*>(m_offset);
+        const auto aligned_address = std::align(alignof(T), sizeof(T), pointer, remaining_num_bytes);
+        if (aligned_address == nullptr) {
+            throw std::bad_alloc {};
+        }
+        m_offset = static_cast<std::byte*>(aligned_address) + sizeof(T);
+        return static_cast<T*>(aligned_address);
     }
 
-    inline ArenaAllocator(const ArenaAllocator& other) = delete;
-
-    inline ArenaAllocator operator=(const ArenaAllocator& other) = delete;
-
-    inline ~ArenaAllocator()
+    template <typename T, typename... Args>
+    [[nodiscard]] T* emplace(Args&&... args)
     {
-        free(m_buffer);
+        const auto allocated_memory = alloc<T>();
+        return new (allocated_memory) T { std::forward<Args>(args)... };
+    }
+
+    ~ArenaAllocator()
+    {
+        // No destructors are called for the stored objects. Thus, memory
+        // leaks are possible (e.g. when storing std::vector objects or
+        // other non-trivially destructable objects in the allocator).
+        // Although this could be changed, it would come with additional
+        // runtime overhead and therefore is not implemented.
+        delete[] m_buffer;
     }
 
 private:
-    size_t m_size;
+    std::size_t m_size;
     std::byte* m_buffer;
     std::byte* m_offset;
 };

--- a/src/parser.hpp
+++ b/src/parser.hpp
@@ -91,17 +91,13 @@ public:
     std::optional<NodeTerm*> parse_term()
     {
         if (auto int_lit = try_consume(TokenType::int_lit)) {
-            auto term_int_lit = m_allocator.alloc<NodeTermIntLit>();
-            term_int_lit->int_lit = int_lit.value();
-            auto term = m_allocator.alloc<NodeTerm>();
-            term->var = term_int_lit;
+            auto term_int_lit = m_allocator.emplace<NodeTermIntLit>(int_lit.value());
+            auto term = m_allocator.emplace<NodeTerm>(term_int_lit);
             return term;
         }
         else if (auto ident = try_consume(TokenType::ident)) {
-            auto expr_ident = m_allocator.alloc<NodeTermIdent>();
-            expr_ident->ident = ident.value();
-            auto term = m_allocator.alloc<NodeTerm>();
-            term->var = expr_ident;
+            auto expr_ident = m_allocator.emplace<NodeTermIdent>(ident.value());
+            auto term = m_allocator.emplace<NodeTerm>(expr_ident);
             return term;
         }
         else if (auto open_paren = try_consume(TokenType::open_paren)) {
@@ -111,10 +107,8 @@ public:
                 exit(EXIT_FAILURE);
             }
             try_consume(TokenType::close_paren, "Expected `)`");
-            auto term_paren = m_allocator.alloc<NodeTermParen>();
-            term_paren->expr = expr.value();
-            auto term = m_allocator.alloc<NodeTerm>();
-            term->var = term_paren;
+            auto term_paren = m_allocator.emplace<NodeTermParen>(expr.value());
+            auto term = m_allocator.emplace<NodeTerm>(term_paren);
             return term;
         }
         else {
@@ -128,8 +122,7 @@ public:
         if (!term_lhs.has_value()) {
             return {};
         }
-        auto expr_lhs = m_allocator.alloc<NodeExpr>();
-        expr_lhs->var = term_lhs.value();
+        auto expr_lhs = m_allocator.emplace<NodeExpr>(term_lhs.value());
 
         while (true) {
             std::optional<Token> curr_tok = peek();
@@ -150,34 +143,26 @@ public:
                 std::cerr << "Unable to parse expression" << std::endl;
                 exit(EXIT_FAILURE);
             }
-            auto expr = m_allocator.alloc<NodeBinExpr>();
-            auto expr_lhs2 = m_allocator.alloc<NodeExpr>();
+            auto expr = m_allocator.emplace<NodeBinExpr>();
+            auto expr_lhs2 = m_allocator.emplace<NodeExpr>();
             if (op.type == TokenType::plus) {
-                auto add = m_allocator.alloc<NodeBinExprAdd>();
                 expr_lhs2->var = expr_lhs->var;
-                add->lhs = expr_lhs2;
-                add->rhs = expr_rhs.value();
+                auto add = m_allocator.emplace<NodeBinExprAdd>(expr_lhs2, expr_rhs.value());
                 expr->var = add;
             }
             else if (op.type == TokenType::star) {
-                auto multi = m_allocator.alloc<NodeBinExprMulti>();
                 expr_lhs2->var = expr_lhs->var;
-                multi->lhs = expr_lhs2;
-                multi->rhs = expr_rhs.value();
+                auto multi = m_allocator.emplace<NodeBinExprMulti>(expr_lhs2, expr_rhs.value());
                 expr->var = multi;
             }
             else if (op.type == TokenType::minus) {
-                auto sub = m_allocator.alloc<NodeBinExprSub>();
                 expr_lhs2->var = expr_lhs->var;
-                sub->lhs = expr_lhs2;
-                sub->rhs = expr_rhs.value();
+                auto sub = m_allocator.emplace<NodeBinExprSub>(expr_lhs2, expr_rhs.value());
                 expr->var = sub;
             }
             else if (op.type == TokenType::fslash) {
-                auto div = m_allocator.alloc<NodeBinExprDiv>();
                 expr_lhs2->var = expr_lhs->var;
-                div->lhs = expr_lhs2;
-                div->rhs = expr_rhs.value();
+                auto div = m_allocator.emplace<NodeBinExprDiv>(expr_lhs2, expr_rhs.value());
                 expr->var = div;
             }
             else {
@@ -193,7 +178,7 @@ public:
         if (!try_consume(TokenType::open_curly).has_value()) {
             return {};
         }
-        auto scope = m_allocator.alloc<NodeScope>();
+        auto scope = m_allocator.emplace<NodeScope>();
         while (auto stmt = parse_stmt()) {
             scope->stmts.push_back(stmt.value());
         }
@@ -207,7 +192,7 @@ public:
             && peek(1).value().type == TokenType::open_paren) {
             consume();
             consume();
-            auto stmt_exit = m_allocator.alloc<NodeStmtExit>();
+            auto stmt_exit = m_allocator.emplace<NodeStmtExit>();
             if (auto node_expr = parse_expr()) {
                 stmt_exit->expr = node_expr.value();
             }
@@ -217,7 +202,7 @@ public:
             }
             try_consume(TokenType::close_paren, "Expected `)`");
             try_consume(TokenType::semi, "Expected `;`");
-            auto stmt = m_allocator.alloc<NodeStmt>();
+            auto stmt = m_allocator.emplace<NodeStmt>();
             stmt->var = stmt_exit;
             return stmt;
         }
@@ -226,7 +211,7 @@ public:
             && peek(1).value().type == TokenType::ident && peek(2).has_value()
             && peek(2).value().type == TokenType::eq) {
             consume();
-            auto stmt_let = m_allocator.alloc<NodeStmtLet>();
+            auto stmt_let = m_allocator.emplace<NodeStmtLet>();
             stmt_let->ident = consume();
             consume();
             if (auto expr = parse_expr()) {
@@ -237,14 +222,13 @@ public:
                 exit(EXIT_FAILURE);
             }
             try_consume(TokenType::semi, "Expected `;`");
-            auto stmt = m_allocator.alloc<NodeStmt>();
+            auto stmt = m_allocator.emplace<NodeStmt>();
             stmt->var = stmt_let;
             return stmt;
         }
         else if (peek().has_value() && peek().value().type == TokenType::open_curly) {
             if (auto scope = parse_scope()) {
-                auto stmt = m_allocator.alloc<NodeStmt>();
-                stmt->var = scope.value();
+                auto stmt = m_allocator.emplace<NodeStmt>(scope.value());
                 return stmt;
             }
             else {
@@ -254,7 +238,7 @@ public:
         }
         else if (auto if_ = try_consume(TokenType::if_)) {
             try_consume(TokenType::open_paren, "Expected `(`");
-            auto stmt_if = m_allocator.alloc<NodeStmtIf>();
+            auto stmt_if = m_allocator.emplace<NodeStmtIf>();
             if (auto expr = parse_expr()) {
                 stmt_if->expr = expr.value();
             }
@@ -270,8 +254,7 @@ public:
                 std::cerr << "Invalid scope" << std::endl;
                 exit(EXIT_FAILURE);
             }
-            auto stmt = m_allocator.alloc<NodeStmt>();
-            stmt->var = stmt_if;
+            auto stmt = m_allocator.emplace<NodeStmt>(stmt_if);
             return stmt;
         }
         else {


### PR DESCRIPTION
The current implementation of the `ArenaAllocator` class has some problems:

* The memory alignment requirements for newly allocated objects are ignored.
* No constructors are called during allocation which leads to issues (especially problematic when allocating objects of non-POD types).

Both these issues lead to undefined behavior.

This pull request tries to improve and fix the implementation. The `alloc()` member function now respects the alignment requirements and also checks if there's enough free memory in the allocator (throws otherwise). However, just like before, the `alloc()` function still does ***not*** call any constructors.
Therefore, another member function called `emplace()` has been introduced to guarantee initializing an object upon allocation (by either default-initializing it or calling one of its constructors).

For example:
```cpp
auto allocator = ArenaAllocator{ 1024 * 1024 }; // 1 MiB

auto a = allocator.alloc<int>(); // correct alignment, but uninitialized
std::cout << *a << '\n'; // undefined behavior (accessing uninitialized memory)

auto b = allocator.emplace<int>(); // correct alignment, default-initialized
std::cout << *b << '\n'; // okay, prints '0'

auto c = allocator.alloc<std::vector<int>>();
c->push_back(42); // undefined behavior (constructor of std::vector was never called)

auto d = allocator.emplace<std::vector<int>>();
d->push_back(42); // ok
```

Personally, I think the `alloc()` function should be made `private` to avoid creating uninitialized objects. This PR already replaces all calls to `alloc()` with calls to `emplace()`, but I did not want to enforce this change.