### PR TITLE
Improve parser's error comments

### DIFF
--- a/src/tokenization.hpp
+++ b/src/tokenization.hpp
@@ -107,6 +107,9 @@ public:
                     if (peek().value() == '*' && peek(1).has_value() && peek(1).value() == '/') {
                         break;
                     }
+                    if (peek().value() == '/n'){
+                        tokens.push_back({ .type = TokenType::line_break })
+                    }
                     consume();
                 }
                 if (peek().has_value()) {

--- a/src/tokenization.hpp
+++ b/src/tokenization.hpp
@@ -21,6 +21,7 @@ enum class TokenType {
     if_,
     elif,
     else_,
+    line_break,
 };
 
 inline std::optional<int> bin_prec(const TokenType type)
@@ -157,6 +158,7 @@ public:
             }
             else if (std::isspace(peek().value())) {
                 consume();
+                tokens.push_back({ .type = TokenType:: line_break });
             }
             else {
                 std::cerr << "You messed up!" << std::endl;


### PR DESCRIPTION
Errors the compiler finds while parsing now give the line of where the error occurred, as well as more information regarding the  error itself.