### PR TITLE
Fixed If Statement Logic Error

### DIFF
--- a/src/generation.hpp
+++ b/src/generation.hpp
@@ -204,10 +204,10 @@ public:
                 gen.m_output << "    test rax, rax\n";
                 gen.m_output << "    jz " << label << "\n";
                 gen.gen_scope(stmt_if->scope);
-                gen.m_output << "    jmp " << label << "\n";
+                const std::string end_label = gen.create_label();
+                gen.m_output << "    jmp " << end_label << "\n";
                 gen.m_output << label << ":\n";
                 if (stmt_if->pred.has_value()) {
-                    const std::string end_label = gen.create_label();
                     gen.gen_if_pred(stmt_if->pred.value(), end_label);
                     gen.m_output << end_label << ":\n";
                 }


### PR DESCRIPTION
If statements would not skip to the end of the if-elif-else structure if they were true and didn't have an `exit()` inside of them.

For example with the following code
```
let x = 1;
if (x) {
    //exit(1);
}
elif (x + 1) {
    exit(2);
}
elif (x + 2) {
    exit(3);
}
else {
    exit(13);
}
exit(14);
```
You would expect the result to be 14 but instead we get 2 because after the if statement executes it jumps to the next elif statement instead of to the end of the structure.

This pull request just modifies two lines of code to fix that issue.